### PR TITLE
In simulator, use health  instead of bestHealth

### DIFF
--- a/html/foodguide.js
+++ b/html/foodguide.js
@@ -2394,9 +2394,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 				names = {};
 				tags = {};
 				setIngredientValues(items, names, tags);
-				tags.hunger = tags.bestHunger;
-				tags.health = tags.bestHealth;
-				tags.sanity = tags.bestSanity;
+				// tags.hunger = tags.bestHunger;
+				// tags.health = tags.bestHealth;
+				// tags.sanity = tags.bestSanity;
 				for (i = 0; i < recipes.length; i++) {
 					recipes[i].test(null, names, tags)
 						&& (recipes[i].modeMask & modeMask) !== 0


### PR DESCRIPTION
In simulator, the combined value show food's best value, such bestHealth, bestHunger, bestSanity.
I reviewed the repo and found in it was added in 29458b78c010e5b2faa82c0995a42318d2be1f74.
I got confused with this. 
For example. In simulator tab, I found _Tallbird Egg_ and _Fried Tallbird Egg_ have same value of Health and Hunger, so in the game I did not cook the Egg and eat it. After that I found it's value of Health and Hunger was out of my expect. 
I thought this was a bug, so I tried to fix it