### PR TITLE
Turn of Tides Food Ingredient Additions (& Recipe Issues Going Forward)

### DIFF
--- a/html/Turn of Tides Food Ingredient Additions
+++ b/html/Turn of Tides Food Ingredient Additions
@@ -53,7 +53,7 @@ food = {
 			},
 	
 	moon_tree_blossom: {
-				name: 'Moon Moth Wings',
+				name: 'Lune Blossoms',
 				uncookable: true,
 				isveggie: true,
 				decoration: 2,

--- a/html/Turn of Tides Food Ingredient Additions
+++ b/html/Turn of Tides Food Ingredient Additions
@@ -1,0 +1,89 @@
+food = {
+	
+	//DST Turn Of Tides Ingredient Additions	
+	kelp: {
+				name: 'Kelp Fronds',
+				uncookable: true,
+				isveggie: true,
+				health: -healing_tiny,
+				hunger: calories_tiny,
+				sanity: -sanity_small,
+				perish: perish_med,
+				stack: stack_size_smallitem,
+				dry: 'kelp_dried',
+				drytime: dry_superfast
+				mode: 'together'
+			},
+			
+	kelp_cooked: {
+				name: 'Cooked Kelp Fronds',
+				uncookable: true,
+				isveggie: true,
+				veggie: 1,
+				health: 0,
+				hunger: calories_tiny,
+				sanity: -sanity_tiny,
+				perish: perish_med,
+				stack: stack_size_smallitem,
+				mode: 'together'
+			},
+	
+	kelp_dried: {
+				name: 'Dried Kelp Fronds',
+				uncookable: true,
+				isveggie: true,
+				veggie: 1,
+				health: healing_tiny,
+				hunger: calories_tiny,
+				sanity: sanity_small,
+				perish: perish_preserved,
+				stack: stack_size_smallitem,
+				mode: 'together'
+			},
+
+	moonbutterflywings: {
+				name: 'Moon Moth Wings',
+				isveggie: true,
+				decoration: 2,
+				health: healing_medsmall,
+				hunger: calories_tiny,
+				sanity: sanity_med,
+				perish: perish_fast,
+				stack: stack_size_smallitem
+			},
+	
+	moon_tree_blossom: {
+				name: 'Moon Moth Wings',
+				uncookable: true,
+				isveggie: true,
+				decoration: 2,
+				health: healing_tiny,
+				hunger: 0,
+				sanity: 0,
+				perish: perish_fast,
+				stack: stack_size_smallitem
+			},
+	
+	rock_avocado_fruit_ripe: {
+				name: 'Ripe Stone Fruit',
+				isveggie: true,
+				veggie: 1,
+				health: healing_tiny,
+				hunger: calories_small,
+				sanity: 0,
+				perish: perish_superfast,
+				stack: stack_size_smallitem
+			},
+	
+	rock_avocado_fruit_ripe_cooked: {
+				name: 'Cooked Stone Fruit',
+				isveggie: true,
+				veggie: 1,
+				health: healing_small,
+				hunger: calories_small,
+				sanity: 0,
+				perish: perish_two_day,
+				stack: stack_size_smallitem
+			},
+}
+


### PR DESCRIPTION
This is the foods ingredients added to Don't Starve Together from the Turn of Tides update:

Kelp Fronds, Cooked Kelp Fronds, & Dried Kelp Fronds
Moon Moth Wings
Lune Blossoms
Ripe Rock Fruit & Cooked Rock Fruit

I would add the images for these, but I don't know how.

Issues:
The recipes for Butter Muffin & Guacamole are different from the DS version of the game. 
1. Moon Moth Wings can substitute Butterfly Wings for Butter Muffin.
2. Ripe Stone Fruit can substitute Cactus Flesh for Guacamole. 

There may be other recipe conflicts for crockpot meals that exist both in DS/RoG and DST but have different recipes, but for now, these are the two I'm aware of.