### PR TITLE
[DST] Trail Mix Fix

### DIFF
--- a/html/food.js
+++ b/html/food.js
@@ -1794,6 +1794,7 @@ export const food = {
 
 	acorn_dst: {
 		name: 'Birchnut',
+		seed: 1,
 		perish: perish_preserved,
 		stack: stack_size_smallitem,
 		cook: 'acorn_cooked_dst',

--- a/html/recipes.js
+++ b/html/recipes.js
@@ -1419,7 +1419,7 @@ export const recipes = {
 	trailmix_dst: {
 		name: 'Trail Mix',
 		test: (cooker, names, tags) => {
-			return (names.acorn_dst || names.acorn_cooked) && tags.seed && tags.seed >= 1 && (names.berries_dst || names.berries_cooked_dst || names.berries_juicy || names.berries_juicy_cooked) && tags.fruit && tags.fruit >= 1 && !tags.meat && !tags.veggie && !tags.egg && !tags.dairy;
+			return (names.acorn_dst || names.acorn_cooked_dst) && tags.seed && tags.seed >= 1 && (names.berries_dst || names.berries_cooked_dst || names.berries_juicy || names.berries_juicy_cooked) && tags.fruit && tags.fruit >= 1 && !tags.meat && !tags.veggie && !tags.egg && !tags.dairy;
 			
 		},
 		requirements: [NAME('acorn'), TAG('seed', COMPARE('>=', 1)), NAME('berries'), TAG('fruit', COMPARE('>=', 1)), NOT(TAG('meat')), NOT(TAG('veggie')), NOT(TAG('egg')), NOT(TAG('dairy'))],


### PR DESCRIPTION
The recipe for the DST version of trail mix was testing for the non-DST version of cooked birchnuts, meaning cooked birchnuts would not meet the condition for having birchnuts. Additionally, uncooked birchnuts had no seed value, meaning uncooked birchnuts would not meet the condition for having seeds. This meant that the only valid recipes for trail mix in DST mode were those that included _both_ a cooked birchnut _and_ an uncooked birchnut, instead of recipes that contained either.

This should fix that.