### PR TITLE
Append _dst to the DST versions of Fresh Fruit Crepes and Monster Tartare

### DIFF
--- a/html/recipes.js
+++ b/html/recipes.js
@@ -2184,7 +2184,7 @@ export const recipes = {
 		cooktime: 2,
 		mode: 'warlydst'
 	},
-	monstertartare: {
+	monstertartare_dst: {
 		name: 'Monster Tartare',
 		test: (cooker, names, tags) => {
 			return tags.monster && tags.monster >= 2 && !tags.inedible;
@@ -2199,7 +2199,7 @@ export const recipes = {
 		cooktime: 0.5,
 		mode: 'warlydst'
 	},
-	freshfruitcrepes: {
+	freshfruitcrepes_dst: {
 		name: 'Fresh Fruit Crepes',
 		test: (cooker, names, tags) => {
 			return tags.fruit && tags.fruit >= 1.5 && names.butter_dst && names.honey_dst;


### PR DESCRIPTION
The DST versions of Fresh Fruit Crepes and Monster Tartare used the same name as the Shipwrecked versions, causing them to override those versions. Appending _dst to their names will prevent them from overriding the Shipwrecked versions.