### PR TITLE
Update Fandom.com wiki links to wiki.gg

### DIFF
--- a/html/foodguide.js
+++ b/html/foodguide.js
@@ -746,7 +746,7 @@ import { isBestStat, isStat, makeImage, makeLinkable, makeElement, pl } from './
 		node.setAttribute('target', '_blank');
 		node.setAttribute(
 			'href',
-			'https://dontstarve.fandom.com/wiki/' + name.replace(/\s/g, '_'),
+			'https://dontstarve.wiki.gg/wiki/' + name.replace(/\s/g, '_'),
 		);
 
 		const text = document.createTextNode(name);

--- a/html/index.htm
+++ b/html/index.htm
@@ -160,10 +160,10 @@
 					</h3>
 
 					<ul>
-						<li><a href="https://dontstarve.fandom.com/wiki/Food" target="_blank">Food</a></li>
-						<li><a href="https://dontstarve.fandom.com/wiki/Cooking" target="_blank">Cooking</a></li>
-						<li><a href="https://dontstarve.fandom.com/wiki/Crock_Pot" target="_blank">Crock Pot</a></li>
-						<li><a href="https://dontstarve.fandom.com/wiki/Farming" target="_blank">Farming</a></li>
+						<li><a href="https://dontstarve.wiki.gg/wiki/Food" target="_blank">Food</a></li>
+						<li><a href="https://dontstarve.wiki.gg/wiki/Cooking" target="_blank">Cooking</a></li>
+						<li><a href="https://dontstarve.wiki.gg/wiki/Crock_Pot" target="_blank">Crock Pot</a></li>
+						<li><a href="https://dontstarve.wiki.gg/wiki/Farming" target="_blank">Farming</a></li>
 					</ul>
 
 					<h2>Sections</h2>
@@ -225,7 +225,7 @@
 						<li><a href="https://github.com/bluehexagons/foodguide/commits/main" target="_blank">Food Guide Change Log</a></li>
 						<li><a href="https://github.com/bluehexagons/foodguide/issues" target="_blank">Report Food Guide Bugs or Issues</a></li>
 						<li><a href="https://www.klei.com/games/dont-starve" target="_blank">Don't Starve Official Website</a></li>
-						<li><a href="https://dontstarve.fandom.com/" target="_blank">Don't Starve Wiki on Fandom</a></li>
+						<li><a href="https://dontstarve.wiki.gg/" target="_blank">Don't Starve Wiki on Fandom</a></li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
This PR updates all instances of and references to the old Fandom.com wiki to [the independent Don't Starve Wiki hosted on wiki.gg](https://dontstarve.wiki.gg/), including static links and links generated by the JavaScript files.

Fandom Wiki has a lot of problems and has been embroiled in controversy, including hyper-aggressive advertising/cross-promotion for websites and online content under their brand, and a very restrictive forking policy that prevents editors from moving away from it easily.

In addition, the Fandom wiki admins have been noted to partner with corporate sponsors to turn articles into giant advertisements, ruining the page's informational value (i.e. the McDonald's fandom wiki has the entire article on the character Grimace changed into a promotion for the Grimace Shake meal back when that was trending.) I recommend [mossbag's video](https://www.youtube.com/watch?v=qcfuA_UAz3I) or [DIMM4's video](https://www.youtube.com/watch?v=ySXP4hxFNFw) on Fandom wiki if you want to learn more.