### PR TITLE
Remove "on Fandom" from wiki link text

### DIFF
--- a/html/index.htm
+++ b/html/index.htm
@@ -222,10 +222,10 @@
 					</h2>
 
 					<ul>
-						<li><a href="https://github.com/bluehexagons/foodguide/commits/main" target="_blank">Food Guide Change Log</a></li>
-						<li><a href="https://github.com/bluehexagons/foodguide/issues" target="_blank">Report Food Guide Bugs or Issues</a></li>
+						<li><a href="https://github.com/bluehexagons/foodguide/commits/main" target="_blank">Food Guide Changelog</a></li>
+						<li><a href="https://github.com/bluehexagons/foodguide/issues" target="_blank">Report Food Guide Bugs / Issues</a></li>
 						<li><a href="https://www.klei.com/games/dont-starve" target="_blank">Don't Starve Official Website</a></li>
-						<li><a href="https://dontstarve.wiki.gg/" target="_blank">Don't Starve Wiki on Fandom</a></li>
+						<li><a href="https://dontstarve.wiki.gg/" target="_blank">Don't Starve Wiki</a></li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
Hi, so I forgot to remove the "on Fandom" section from the link to the new wiki. This PR should fix it.